### PR TITLE
Adding a meta description to layout file

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -7,6 +7,10 @@ dotenv.load();
 router.get('/', function(req, res) {
   res.render('index', {
     title: 'WICit: Where to shop with WIC.',
+    description: 'Where and how to get and use WIC: '
+      + 'Find locations that accept WIC in California, '
+      + 'using data from the California Department of '
+      + 'Public Health.',
     mapboxId: process.env.MAPBOX_ID,
     mapboxToken: process.env.MAPBOX_TOKEN,
     apiToken: process.env.API_TOKEN

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -2,6 +2,7 @@ doctype html
 html(ng-app="wicItApp", ng-controller='AppCtrl')
   head
     title= title
+    meta(name='description', content= description)
     meta(name='viewport', content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no')
     link(rel='stylesheet', href='components/leaflet/dist/leaflet.css')
     link(rel='stylesheet', href='components/leaflet.markercluster/dist/MarkerCluster.Default.css')


### PR DESCRIPTION
Quick addition here. I noticed that the WICit page showed up in Google's results with a weird description (possibly pull from map pins?). Anyway, this adds a `<meta />` tag that should fix that, the next time the page is crawled:

![description](https://dl.dropboxusercontent.com/u/42869844/github/2015/wicit%20description.png)

You'll probably want to change the actual sentence I've included, this is a bit under the recommended 150-160 characters.