### PR TITLE
Cache geolocation result to localstorage.

### DIFF
--- a/public/javascripts/controllers/map.js
+++ b/public/javascripts/controllers/map.js
@@ -81,7 +81,7 @@ var MapCtrl = function ($scope, $http, leafletEvents, leafletData, leafletHelper
         var container = L.DomUtil.create('div', 'locate-control');
         // Attach event listeners
         L.DomEvent.addListener(container, 'click', function() {
-          geolocateUser();
+          geolocateUser({forceUpdate: true});
         });
         var controlUI = L.DomUtil.create('div', 'leaflet-control-command-interior', container);
         // controlUI.title = 'Map Commands';
@@ -95,9 +95,9 @@ var MapCtrl = function ($scope, $http, leafletEvents, leafletData, leafletHelper
     };
   }
 
-  function geolocateUser()
+  function geolocateUser(options)
   {
-    GeolocationService.getPosition().then(setUserLocation, geolocationError);
+    GeolocationService.getPosition(options).then(setUserLocation, geolocationError);
   }
 
   function setUserLocation(position)

--- a/public/javascripts/services/geolocation.js
+++ b/public/javascripts/services/geolocation.js
@@ -2,19 +2,37 @@
 var geolocation = angular.module('geolocation', []);
 
 geolocation.factory('GeolocationService', function($q) {
+  var CACHE_LIFETIME = 86400000; // 1 day
   var geolocationInstance = {};
   geolocationInstance.position = false;
-  geolocationInstance.getPosition = function() {
+
+  // Load position from localStorage if possible.
+  if (window.localStorage) {
+    try {
+      geolocationInstance.position = JSON.parse(localStorage.getItem('position'));
+    } catch (e) {
+      geolocationInstance.position = false;
+    }
+
+    // Verify that cache has not expired.
+    var timestamp = geolocationInstance.position ? geolocationInstance.position.timestamp : 0;
+    if (Date.now() - timestamp > CACHE_LIFETIME) {
+      geolocationInstance.position = false;
+    }
+  }
+
+  geolocationInstance.getPosition = function(options) {
+    options = options || {};
     var self = this;
     var deferred = $q.defer();
     // Check cache.
-    if (this.position) {
+    if (this.position && !options.forceUpdate) {
       deferred.resolve(this.position);
     } else {
       if (navigator.geolocation) {
         navigator.geolocation.getCurrentPosition(getCurrentPositionSuccessCallback, getCurrentPositionErrorCallback);
       } else {
-        deferred.reject("Geolocation error.")
+        deferred.reject('Geolocation error.');
       }
     }
 
@@ -26,7 +44,15 @@ geolocation.factory('GeolocationService', function($q) {
     function getCurrentPositionSuccessCallback(pos) {
       // Cache result;
       self.position = pos;
-      deferred.resolve(self.position)
+      deferred.resolve(self.position);
+
+      if (window.localStorage) {
+        try {
+          localStorage.setItem('position', encodePosition(pos));
+        } catch (e) {
+          // LocalStorage may be disabled.
+        }
+      }
     }
 
     /**
@@ -36,6 +62,28 @@ geolocation.factory('GeolocationService', function($q) {
       deferred.reject(posError);
     }
 
+    /**
+     * Firefox and IE9 put properties onto the Position prototype,
+     *   not the object itself, which is technically correct but
+     *   breaks JSON.stringify(). To get around this, manually
+     *   copy the properties we're interested in.
+     *
+     * NOTE: Desktop Safari returns January 1, 2001 as the timestamp,
+     *   so we'll use Date.now() instead. Details:
+     *   http://stackoverflow.com/a/11071426
+     *
+     * @param pos
+     */
+    function encodePosition (pos) {
+      return JSON.stringify({
+        timestamp: Date.now(), // (see above)
+        coords: {
+          accuracy: pos.coords.accuracy,
+          latitude: pos.coords.latitude,
+          longitude: pos.coords.longitude
+        }
+      });
+    }
   };
   //factory function body that constructs shinyNewServiceInstance
   return geolocationInstance;


### PR DESCRIPTION
Fixes #18. Caches geolocation result to localStorage for ~24 hours.

~~**NOTE:** *This isn't quite ready to be merged (there's a bug in Safari I need to look into), but I thought I'd get feedback about the approach, like using localStorage as opposed to cookies or another session storage method.*~~

This wouldn't need to be localStorage (interested to hear your thoughts) but here's my reasoning:

1. Generic session storage can be kept in cookies, server memory, or another datastore, but usually involves either (a) including it in the page body or (b) making an AJAX request for that data. Since (a) would break any future possibility of using a CDN like CloudFlare to add caching or HTTPS, and (b) would dramatically slow down the pageload, it might be better to keep this client-side.
2. Cookies have rather particular encoding needs (no semicolons, commas, or whitespace) so we'd probably want to use one of the jQuery cookie plugins if we went that route. Plugins are meh.
3. LocalStorage is supported on all browsers that support the geolocation API (as far as I know), and doesn't require any plugins.