### PR TITLE
Update API endpoint, fixes #41

### DIFF
--- a/public/javascripts/controllers/map.js
+++ b/public/javascripts/controllers/map.js
@@ -10,7 +10,7 @@ wicItApp.controller('MapCtrl', function ($scope, $http, leafletEvents, leafletDa
   var mapToken = Constants.mapboxToken;
   var locationsApiToken = Constants.apiToken;
   var tileUrl = "https://{s}.tiles.mapbox.com/v3/" + mapId + "/{z}/{x}/{y}.png?access_token=" + mapToken;
-  var locationsBaseUrl = 'http://cdph.data.ca.gov/resource/i7wi-ei4m.json';
+  var locationsBaseUrl = 'https://chhs.data.ca.gov/resource/x5nq-b49e.json';
   var prevBounds = false;
   var curBounds = false;
 


### PR DESCRIPTION
The California Health and Human Services Agency has migrated the dataset to a new API endpoint. I'm not sure if this requires a new API token, but I've replaced the URL. You can find it here: 

https://chhs.data.ca.gov/Facilities-and-Services/Women-Infants-and-Children-WIC-Authorized-Vendors/x5nq-b49e